### PR TITLE
updating the github action scripts

### DIFF
--- a/.github/workflows/linux_debian.yml
+++ b/.github/workflows/linux_debian.yml
@@ -1,0 +1,163 @@
+name: Linux Debian builds
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - develop
+    paths-ignore:
+      - '.github/workflows/windows.yml'
+      - '.github/workflows/unix_mac.yml'
+      - '.github/workflows/linux_ubuntu.yml'
+      - '*.md'
+      - 'LICENSE'
+
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - '.github/workflows/windows.yml'
+      - '.github/workflows/unix_mac.yml'
+      - '.github/workflows/linux_ubuntu.yml'
+      - '*.md'
+      - 'LICENSE'
+
+  release:
+    types: # This configuration does not affect the page_build event above
+      - published
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  building-plugin:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cubit: [2021.5, 2021.11]
+        os: [debian]
+        # using a 'string' for version number as the 0 gets rounded away otherwise
+        os_version: ['10.10']
+   
+    name: 'Cubit ${{ matrix.cubit }} Build for ${{ matrix.os }} ${{ matrix.os_version }} of Svalinn Plugin'
+
+    container:
+      image:  ${{ matrix.os }}:${{ matrix.os_version }}
+
+    steps:
+      - name: install new git
+        shell: bash -l {0}
+        run: |
+          apt-get update
+          apt-get install -y software-properties-common curl
+          apt-get install -y git
+      - uses: actions/checkout@v2
+
+      - name: Environment Variables
+        shell: bash -l {0}
+        run: |
+          COREFORM_BASE_URL=https://f002.backblazeb2.com/file/cubit-downloads/Coreform-Cubit/Releases
+
+          if [ "${{ matrix.cubit }}" == "2021.4" ]; then
+            BASE=Coreform-Cubit-2021.4%2B15017_05893177
+            CUBIT_BASE_NAME=Coreform-Cubit-2021.4
+            HDF5_PATH=/usr/local/HDF_Group/HDF5/1.12.0
+          elif [ "${{ matrix.cubit }}" == "2021.5" ]; then
+            BASE=Coreform-Cubit-2021.5%2B15962_5043ef39
+            CUBIT_BASE_NAME=Coreform-Cubit-2021.5
+            HDF5_PATH=/usr/local/HDF_Group/HDF5/1.12.0
+          elif [ "${{ matrix.cubit }}" == "2021.11" ]; then
+            BASE=Coreform-Cubit-2021.11%2B21637_35609873
+            CUBIT_BASE_NAME=Coreform-Cubit-2021.11
+            HDF5_PATH=/usr/local/HDF_Group/HDF5/1.12.0
+          fi
+
+          SUFFIX=Lin64
+          EXT=deb
+          echo "SED=sed" >> $GITHUB_ENV
+          echo "BUILD_SHARED_LIBS=ON" >> $GITHUB_ENV
+          echo "BUILD_STATIC_LIBS=OFF" >> $GITHUB_ENV
+          echo "system=linux" >> $GITHUB_ENV
+          echo "CUBIT_PATH=/opt/${CUBIT_BASE_NAME}" >> $GITHUB_ENV
+          echo "COREFORM_BASE_URL=${COREFORM_BASE_URL}/Linux/" >> $GITHUB_ENV
+          echo "HDF5_PATH=${HDF5_PATH}" >> $GITHUB_ENV
+
+          echo "OS=${{ matrix.os }}" >> $GITHUB_ENV
+          echo "OS_VERSION=${{ matrix.os_version }}" >> $GITHUB_ENV
+          echo "CMAKE_ADDITIONAL_FLAGS=-DCMAKE_CXX_FLAGS=-D_GLIBCXX_USE_CXX11_ABI=0" >> $GITHUB_ENV
+
+          echo "CUBIT_PKG=${BASE}-${SUFFIX}.${EXT}" >> $GITHUB_ENV
+          echo "CUBIT_SDK_PKG=${BASESDK}-${SUFFIX}.tar.gz" >> $GITHUB_ENV
+          echo "CUBIT_BASE_NAME=${CUBIT_BASE_NAME}" >> $GITHUB_ENV
+
+          echo "CURRENT=$(pwd)" >> $GITHUB_ENV
+          echo "SCRIPTPATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "PLUGIN_ABS_PATH=$GITHUB_WORKSPACE/.." >> $GITHUB_ENV
+          echo "FOLDER_PKG=$GITHUB_WORKSPACE/pkg" >> $GITHUB_ENV
+
+          echo "" >> ${HOME}/.bash_profile
+          echo "source $GITHUB_WORKSPACE/scripts/unix_share_build.sh" >> $HOME/.bash_profile
+      
+      - name: Initial setup
+        shell: bash -l {0}
+        run: |
+          ${system}_install_prerequisites
+ 
+      - name: Downloading packages
+        shell: bash -l {0}
+        run: |
+          mkdir -p $FOLDER_PKG
+          cd ${FOLDER_PKG}
+          curl -L ${COREFORM_BASE_URL}${CUBIT_PKG} --output ${CUBIT_PKG}
+          if [ "${{ matrix.cubit }}" = "17.1.0" ]; then
+            curl -L ${COREFORM_BASE_URL}${CUBIT_SDK_PKG} --output ${CUBIT_SDK_PKG}
+          fi
+          mkdir ${SCRIPTPATH}/release
+
+      - name: Cubit setup
+        shell: bash -l {0}
+        run: |
+          ${system}_setup_cubit ${{ matrix.cubit }}
+
+      - name: Build HDF5
+        shell: bash -l {0}
+        run: |
+          ${system}_build_hdf5
+
+      - name: Build MOAB
+        shell: bash -l {0}
+        run: |
+          build_moab
+
+      - name: Build DAGMC
+        shell: bash -l {0}
+        run: |
+          build_dagmc
+
+      - name: Build plugin
+        shell: bash -l {0}
+        run: |
+          build_plugin 
+
+      - name: Prepare package
+        shell: bash -l {0}
+        run: |
+          ${system}_build_plugin_pkg ${{ matrix.cubit }}
+
+      - if: github.event_name != 'release'
+        name: Upload artifact for CI
+        uses: actions/upload-artifact@v2
+        with:
+          name: svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
+          path: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
+          if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
+    
+      - if: github.event_name == 'release'
+        name: Upload binaries into the release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
+          asset_name: svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/.github/workflows/linux_debian.yml
+++ b/.github/workflows/linux_debian.yml
@@ -152,12 +152,8 @@ jobs:
           path: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
     
-      - if: github.event_name == 'release'
-        name: Upload binaries into the release
-        uses: svenstaro/upload-release-action@v2
+      - name: Upload binaries into the release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
-          asset_name: svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
-          tag: ${{ github.ref }}
-          overwrite: true
+          files: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz

--- a/.github/workflows/linux_ubuntu.yml
+++ b/.github/workflows/linux_ubuntu.yml
@@ -34,13 +34,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cubit: [2021.4, 2021.5, 2021.11]
+        cubit: [2021.5, 2021.11]
         os: [ubuntu]
         os_version: [20.04, 21.04]
         include:
           - os: ubuntu
             os_version: 18.04
             cubit: 17.1.0
+        include:
+          - os: ubuntu
+            os_version: 20.04
+            cubit: 2021.4
 
     name: 'Cubit ${{ matrix.cubit }} Build for ${{ matrix.os }} ${{ matrix.os_version }} of Svalinn Plugin'
 

--- a/.github/workflows/linux_ubuntu.yml
+++ b/.github/workflows/linux_ubuntu.yml
@@ -1,4 +1,4 @@
-name: Linux builds
+name: Linux Ubuntu builds
 
 on:
   # allows us to run workflows manually
@@ -9,6 +9,7 @@ on:
     paths-ignore:
       - '.github/workflows/windows.yml'
       - '.github/workflows/unix_mac.yml'
+      - '.github/workflows/linux_debian.yml'
       - '*.md'
       - 'LICENSE'
 
@@ -18,6 +19,7 @@ on:
     paths-ignore:
       - '.github/workflows/windows.yml'
       - '.github/workflows/unix_mac.yml'
+      - '.github/workflows/linux_debian.yml'
       - '*.md'
       - 'LICENSE'
 
@@ -40,15 +42,6 @@ jobs:
             os_version: 18.04
             cubit: 17.1.0
 
-          - os: debian
-            os_version: '10.10'  # using a 'string' here as the 0 gets rounded away otherwise
-            cubit: 2021.5
-
-          - os: debian
-            os_version: '10.10'  # using a 'string' here as the 0 gets rounded away otherwise
-            cubit: 2021.11
-
-   
     name: 'Cubit ${{ matrix.cubit }} Build for ${{ matrix.os }} ${{ matrix.os_version }} of Svalinn Plugin'
 
     container:
@@ -60,10 +53,8 @@ jobs:
         run: |
           apt-get update
           apt-get install -y software-properties-common curl
-          if [ "${{ matrix.os }}" == "ubuntu" ]; then
-            add-apt-repository ppa:git-core/ppa
-            apt-get update
-          fi
+          add-apt-repository ppa:git-core/ppa
+          apt-get update
           apt-get install -y git
       - uses: actions/checkout@v2
 

--- a/.github/workflows/linux_ubuntu.yml
+++ b/.github/workflows/linux_ubuntu.yml
@@ -162,12 +162,8 @@ jobs:
           path: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
     
-      - if: github.event_name == 'release'
-        name: Upload binaries into the release
-        uses: svenstaro/upload-release-action@v2
+      - name: Upload binaries into the release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
-          asset_name: svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz
-          tag: ${{ github.ref }}
-          overwrite: true
+          files: ${{ github.workspace }}/release/svalinn-plugin_${{ matrix.os }}-${{ matrix.os_version }}_cubit_${{ matrix.cubit }}.tgz

--- a/.github/workflows/linux_ubuntu.yml
+++ b/.github/workflows/linux_ubuntu.yml
@@ -41,7 +41,7 @@ jobs:
           - os: ubuntu
             os_version: 18.04
             cubit: 17.1.0
-        include:
+
           - os: ubuntu
             os_version: 20.04
             cubit: 2021.4

--- a/.github/workflows/unix_mac.yml
+++ b/.github/workflows/unix_mac.yml
@@ -142,13 +142,9 @@ jobs:
           name: svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz
           path: ${{ github.workspace }}/release/svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
-    
-      - if: github.event_name == 'release'
-        name: Upload binaries into the release
-        uses: svenstaro/upload-release-action@v2
+
+      - name: Upload binaries into the release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ github.workspace }}/release/svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz
-          asset_name: svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz
-          tag: ${{ github.ref }}
-          overwrite: true
+          files: ${{ github.workspace }}/release/svalinn-plugin_${{env.OS}}_cubit_${{ matrix.cubit }}.tgz

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -204,13 +204,9 @@ jobs:
           name: svalinn-plugin_windows_${{ matrix.cubit }}.zip
           path: C:/Users/runneradmin/svalinn_plugin_windows_${{ matrix.cubit }}.zip
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn` 
-    
-      - if: github.event_name == 'release'
-        name: Upload binaries into the release
-        uses: svenstaro/upload-release-action@v2
+
+      - name: Upload binaries into the release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: C:/Users/runneradmin/svalinn_plugin_windows_${{ matrix.cubit }}.zip
-          asset_name: svalinn_plugin_windows_${{ matrix.cubit }}.zip
-          tag: ${{ github.ref }}
-          overwrite: true
+          files: C:/Users/runneradmin/svalinn_plugin_windows_${{ matrix.cubit }}.zip


### PR DESCRIPTION
The existing Github Actions scripts make use of [upload-release-asset](https://github.com/actions/upload-release-asset) which is now no longer maintained and suggests using [action-gh-release](https://github.com/softprops/action-gh-release) instead.

So I think it might be time to change the GitHub Action used to upload.

Additionally as mentioned in the call today the combined action for Ubuntu and Debian upload was getting a bit large so I've split those two into separate yml files which appears to simplify things.
